### PR TITLE
Add build and release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: "Build and publish binaries"
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+
+  build:
+    name: Build Release
+    needs: create_release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
+    - run: pip install pyinstaller pillow
+    - run: pyinstaller -w -F --distpath ./dist/${{ runner.os }} -i src/icon.icns src/FarmUpload.py
+    - run: |
+        cp settings-example.json dist/${{ runner.os }}/
+        zip -r FarmUpload-${{ runner.os }}.zip dist/${{ runner.os }}/*
+      if: matrix.os == 'ubuntu-latest'
+    - run: |
+        cp settings-example.json dist/${{ runner.os }}/
+        zip -r FarmUpload-${{ runner.os }}.zip dist/${{ runner.os }}/*
+      if: matrix.os == 'macos-latest'
+    - run: |
+        copy settings-example.json dist/${{ runner.os }}/
+        powershell Compress-Archive -Path dist -DestinationPath FarmUpload-${{ runner.os }}.zip
+      if: matrix.os == 'windows-latest'
+    - uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ needs.create_release.outputs.tag-name }}
+        files: FarmUpload-${{ runner.os }}.zip


### PR DESCRIPTION
Similar to #5 but uses pyinstaller

This will build and publish the binaries to a release, covering Windows, MacOS and Linux (the latter built on Ubuntu).

Current funniness:
- I was going to use `zip -r -j` on Linux and MacOS to dump the paths, but doing so breaks MacOS .app files. I don't work enough with them to know what the elegant workaround is.
- As a result, I've decided, for uniformity, to include the dist/<os> folder in each release zip.
- This only builds on tags, but I figured that'd be preferable.
- For L42 I was going to use `if: matrix.os == 'ubuntu-latest' || 'macos-latest'` but this also made it run on Windows in my testing. I'm not sure why.