### PR TITLE
Add type annotations

### DIFF
--- a/src/Log.py
+++ b/src/Log.py
@@ -1,16 +1,26 @@
-import tkinter as tk
-import logging
+from __future__ import annotations
 
-class Logger():
+import tkinter as tk
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tkinter.scrolledtext import ScrolledText
+
+
+class Logger:
     """This class allows you to log to a Tkinter Text or ScrolledText widget"""
 
-    def __init__(self, logUI):
+    __slots__ = ("logUI",)
+
+    def __init__(self, logUI: ScrolledText) -> None:
         self.logUI = logUI
 
-    def write(self, message):
+    def write(self, message: str) -> None:
+        """Write new log message"""
         self.logUI.insert(tk.INSERT, message + "\n")
         self.logUI.see("end")
         self.logUI.update()
 
-    def wipe(self):
+    def wipe(self) -> None:
+        """Clear all logs."""
         self.logUI.delete('1.0', tk.END)

--- a/src/Printer.py
+++ b/src/Printer.py
@@ -1,11 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from BambuFTP import BambuFTP
 
-class Printer():
-    def __init__(self, name, ip, pw, enabled):
-        self.name = name;
-        self.ip = ip;
-        self.pw = pw;
+if TYPE_CHECKING:
+    from tkinter import BooleanVar
+    from types import TracebackType
+
+    from typing_extensions import Self
+
+
+class Printer:
+    __slots__ = ("name", "ip", "pw", "enabled", "connected", "ftp")
+
+    def __init__(self, name: str, ip: str, pw: str, enabled: BooleanVar) -> None:
+        self.name = name
+        self.ip = ip
+        self.pw = pw
         self.enabled = enabled
         self.connected = False
 
@@ -14,18 +26,40 @@ class Printer():
         self.ftp.set_pasv(True)
 
 
-    def connect(self):
+    def connect(self) -> bool:
+        """Connect and login to FPT server. Return True on success."""
         try:
             self.ftp.connect(host=self.ip, port=990, timeout=10, source_address=None)
             self.ftp.login('bblp', self.pw)
             self.ftp.prot_p()
             self.connected = True
-        except:
+        except Exception as exc:
             return False
-        
-    def disconnect(self):
+        return True
+
+    def disconnect(self) -> bool:
+        """Disconnect from FPT server. Return True on success."""
         try:
             self.ftp.quit()
             self.connected = False
-        except:
+        except Exception:
             return False
+        return True
+
+    def __enter__(self) -> Self:
+        """Context manager enter."""
+        self.connect()
+        ##if not self.connect():
+        ##    raise ValueError("Error connecting.")
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Context manager exit."""
+        self.disconnect()
+        ##if not self.disconnect():
+        ##    raise ValueError("Error disconnecting.")


### PR DESCRIPTION
This pull request adds type annotations to the project and fixes a bug.

Bug is that currently, when reattempting to send, crashes from AttributeError because "Printer" objects are not indexable.
https://github.com/opulo-inc/farm-upload/blob/73c363aa653e882104f44a029bf3e52edf28e5d9/src/FarmUpload.py#L114
I predict in an earlier version, printer details were stored purely in a dictionary, and this branch was missed when updating, and would have been caught with type checking.